### PR TITLE
Support other than Ubuntu Trusty

### DIFF
--- a/manifests/infra/install.pp
+++ b/manifests/infra/install.pp
@@ -20,8 +20,6 @@ class newrelic::infra::install (
   # probably should be a separate class
   apt::source { 'newrelic-infra':
     location    => 'http://download.newrelic.com/infrastructure_agent/linux/apt',
-    release     => 'trusty',
-    repos       => 'main',
     include_src => false,
     key         => '8ECCE87C',
     key_source  => 'https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg',


### PR DESCRIPTION
main is the default and default for release is the current server release fact.